### PR TITLE
Fixing typo in Manifest.py

### DIFF
--- a/Manifest.py
+++ b/Manifest.py
@@ -3,3 +3,4 @@
 
 modules = {
 "local" : ["RX","Testing","TX"],
+}


### PR DESCRIPTION
HDLmake complains about syntax error, so fixing typo in the Manifest.py.